### PR TITLE
Merge qa to master: Add external configuration section  (#63)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020 IBM Corporation and others.
+// Copyright (c) 2019, 2021 IBM Corporation and others.
 // Licensed under Creative Commons Attribution-NoDerivatives
 // 4.0 International (CC BY-ND 4.0)
 //   https://creativecommons.org/licenses/by-nd/4.0/
@@ -132,8 +132,13 @@ include::finish/inventory/Dockerfile[]
 
 The [hotspot=from file=0]`FROM` instruction initializes a new build stage, which indicates the parent image of the built image. If you don't need a parent image, then you can use `FROM scratch`, which makes your image a base image. 
 
-In this case, you're using the recommended production image, 
-`openliberty/open-liberty:kernel-java8-openj9-ubi`, as your parent image. If you don't want any additional runtime features for your `kernel` image, define the `FROM` instruction as `FROM open-liberty:kernel`. To use the default image that comes with the Open Liberty runtime, define the `FROM` instruction as `FROM open-liberty`. You can find all the official images at https://hub.docker.com/_/open-liberty[open-liberty Docker Hub^].
+In this case, you're using the recommended production image,
+`openliberty/open-liberty:kernel-java8-openj9-ubi`, as your parent image. If you
+don't want any additional runtime features for your `kernel` image, define the
+`FROM` instruction as `FROM open-liberty:kernel`. To use the default image that
+comes with the Open Liberty runtime, define the `FROM` instruction as `FROM
+open-liberty`. You can find all the https://hub.docker.com/_/open-liberty[official images^] and
+https://hub.docker.com/r/openliberty/open-liberty/[ubi images] on the open-liberty Docker Hub.
 
 It is also recommended to label your Docker images with the [hotspot=label file=0]`LABEL` command, as the label information can help you manage your images. For more information, see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#label[Best practices for writing Dockerfiles^].
 
@@ -269,6 +274,78 @@ properties are automatically stored in the inventory. Go back to http://localhos
 you see a new entry for `[system-ip-address]`. 
 
 
+== Externalizing server configuration
+
+// File 0
+inventory/server.xml
+[source, xml, linenums, indent=0, role="code_column"]
+----
+include::finish/inventory/src/main/liberty/config/server.xml[]
+----
+
+As mentioned at the beginning of this guide, one of the advantages of using
+containers is that they are portable and can be moved and deployed efficiently
+across all of your DevOps environments. Configuration often changes across
+different environments, and by externalizing your server configuration, you
+can simplify the development process.
+
+Imagine a scenario where you are developing an Open Liberty application on
+port `9081` but to deploy it to production, it must be available
+on port `9091`. To manage this scenario, you can keep two different versions of the
+`server.xml` file; one for production and one for development. However, trying to
+maintain two different versions of a file might lead to mistakes. A better
+solution would be to externalize the configuration of the port number and use the
+value of an environment variable that is stored in each environment. 
+
+In this example, you will use an environment variable to externally configure the
+HTTP port number of the `inventory` service. 
+
+In the [hotspot file=0]`inventory/server.xml` file, the [hotspot=httpPort
+file=0]`default.http.port` variable is declared and is used in the
+[hotspot=httpEndpoint file=0]`httpEndpoint` element to define the service
+endpoint. The default value of the [hotspot=httpPort file=0]`default.http.port`
+variable is `9081`. However, this value is only used if no other value is
+specified. To find a value for this variable, Open Liberty looks for the
+following environment variables, in order:
+
+* `default.http.port`
+* `default_http_port`
+* `DEFAULT_HTTP_PORT`
+
+When you previously ran the `inventory` container, none of the environment variables mentioned were defined and thus the default value of `9081` was used.
+
+Run the following commands to stop and remove the `inventory` container and rerun it with the `default.http.port` environment variable set:
+
+[role='command']
+```
+docker stop inventory
+docker rm inventory 
+docker run -d --name inventory -e default.http.port=9091 -p 9091:9091 inventory:1.0-SNAPSHOT
+```
+
+The `-e` flag can be used to create and set the values of environment variables
+in a Docker container. In this case, you are setting the `default.http.port` environment
+variable to `9091` for the `inventory` container.
+
+Now, when the service is starting up, Open Liberty finds the
+`default.http.port` environment variable and uses it to set the value of the
+[hotspot=httpPort file=0]`default.http.port` variable to be used in the HTTP
+endpoint.
+
+The `inventory` service will now be available on the new port number you
+specified. You can see the contents of the inventory at
+http://localhost:9091/inventory/systems[http://localhost:9091/inventory/systems^].
+You can add your local system properties at
+`\http://localhost:9091/inventory/systems/pass:c[[system-ip-address]]` by
+replacing `[system-ip-address]` with the IP address you obtained in the previous
+section. The `system` service remains unchanged and is available at
+http://localhost:9080/system/properties[http://localhost:9080/system/properties^]
+
+You can externalize the configuration of more than just the port numbers.
+To learn more about Open Liberty server configuration, check out the
+https://openliberty.io/docs/latest/reference/config/server-configuration-overview.html[Server
+Configuration Overview] docs. 
+
 == Testing the microservices
 
 You can test your microservices manually by hitting the endpoints or with automated tests that check your running Docker containers.
@@ -307,12 +384,12 @@ include::finish/inventory/src/test/java/it/io/openliberty/guides/inventory/Inven
 
 === Running the tests
 
-Run the Maven `package` goal to compile the test classes. Run the Maven `failsafe` goal to test the services that are running in the Docker containers by replacing the `[system-ip-address]` with the IP address that was determined in the previous section.
+Run the Maven `package` goal to compile the test classes. Run the Maven `failsafe` goal to test the services that are running in the Docker containers by replacing the `[system-ip-address]` with the IP address that you determined previously.
 
 [role='command']
 ```
 mvn package
-mvn failsafe:integration-test -Dsystem.ip=[system-ip-address] -Dinventory.http.port=9081 -Dsystem.http.port=9080
+mvn failsafe:integration-test -Dsystem.ip=[system-ip-address] -Dinventory.http.port=9091 -Dsystem.http.port=9080
 ```
 
 If the tests pass, you see a similar output as the following:

--- a/finish/inventory/src/main/liberty/config/server.xml
+++ b/finish/inventory/src/main/liberty/config/server.xml
@@ -7,11 +7,15 @@
     <feature>mpConfig-1.4</feature>
   </featureManager>
 
+  <!-- tag::httpPort[] -->
   <variable name="default.http.port" defaultValue="9081" />
+  <!-- end::httpPort[] -->
   <variable name="default.https.port" defaultValue="9444" />
 
+  <!-- tag::httpEndpoint[] -->
   <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
       id="defaultHttpEndpoint" host="*" />
+  <!-- end::httpEndpoint[] -->
 
   <webApplication location="inventory.war" contextRoot="/">
 


### PR DESCRIPTION
* added section for externalizing server config

* formatting

* refactored to only change inventory port number

* furthers updates

* readme updates

* readme updates

* removed unneed hotspots

* formatting

* fixing link

* fixing link

* title update

* wording changes

* acrolinx updates

* acrolinx updates

* removed triangle brackets from 'httpEndpoint'

* reademe updates

* SME feedback

* ID review updates

* ID review

* Update README.adoc

Co-authored-by: Griffin Hadfield <griffhadfield@gmail.com>
Co-authored-by: Gilbert Kwan <gkwan@ca.ibm.com>