### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -90,7 +90,7 @@ Open another command-line session and run the following Maven goal to build the 
 mvn -pl inventory liberty:run
 ```
 
-// Following context for the static guide:
+// static guide instructions:
 ifndef::cloud-hosted[]
 To access the `inventory` service, which displays the current contents of the inventory, see http://localhost:9081/inventory/systems[http://localhost:9081/inventory/systems^].
 
@@ -99,7 +99,7 @@ The `system` service shows the system properties of the running JVM and can be f
 The system properties of your localhost can be added to the `inventory` service at http://localhost:9081/inventory/systems/localhost[http://localhost:9081/inventory/systems/localhost^].
 endif::[]
 
-// Following context for the cloud-hosted guide:
+// cloud-hosted guide instructions:
 ifdef::cloud-hosted[]
 To access the **inventory** service, which displays the current contents of the inventory, run the following curl command: 
 ```
@@ -284,13 +284,13 @@ container logs for any potential problems. Run the `docker stats system` and `do
 find the cause of the issues, remove the faulty containers with the `docker rm system` and `docker rm inventory` commands. Rebuild
 your images, and start the containers again.
 
-// Following context for the static guide:
+// static guide instructions:
 ifndef::cloud-hosted[]
 To access the application, go to the http://localhost:9081/inventory/systems[http://localhost:9081/inventory/systems^] URL. 
 An empty list is expected because no system properties are stored in the inventory yet. 
 endif::[]
 
-// Following context for the cloud-hosted guide:
+// cloud-hosted guide instructions:
 ifdef::cloud-hosted[]
 To access the application, run the following curl command. 
 An empty list is expected because no system properties are stored in the inventory yet:
@@ -317,7 +317,7 @@ You find the `system` container's IP address:
 
 In this case, the IP address for the `system` service is `172.17.0.2`. Take note of this IP address to add the system properties to the `inventory` service. 
 
-// Following context for the static guide:
+// static guide instructions:
 ifndef::cloud-hosted[]
 Go to the `\http://localhost:9081/inventory/systems/pass:c[[system-ip-address]]` URL by replacing `[system-ip-address]` with the IP address that you obtained earlier.
 You see a result in JSON format with the system properties of your local JVM. When you go to this URL, these system
@@ -325,7 +325,7 @@ properties are automatically stored in the inventory. Go back to the http://loca
 you see a new entry for `[system-ip-address]`. 
 endif::[]
 
-// Following context for the cloud-hosted guide:
+// cloud-hosted guide instructions:
 ifdef::cloud-hosted[]
 Run the following commands to go to the **http://localhost:9081/inventory/systems/[system-ip-address]** by replacing **[system-ip-address]** URL with the IP address that you obtained earlier:
 ```
@@ -400,7 +400,7 @@ Now, when the service is starting up, Open Liberty finds the
 [hotspot=httpPort file=0]`default.http.port` variable to be used in the HTTP
 endpoint.
 
-// Following context for the static guide:
+// static guide instructions:
 ifndef::cloud-hosted[]
 The `inventory` service is now available on the new port number that you
 specified. You can see the contents of the inventory at the 
@@ -412,9 +412,9 @@ section. The `system` service remains unchanged and is available at the
 http://localhost:9080/system/properties[http://localhost:9080/system/properties^] URL.
 endif::[]
 
-// Following context for the cloud-hosted guide:
+// cloud-hosted guide instructions:
 ifdef::cloud-hosted[]
-The `inventory` service is now available on the new port number that you
+The **inventory** service is now available on the new port number that you
 specified. You can see the contents of the inventory at the
 **http://localhost:9091/inventory/systems** URL. Run the following curl command:
 ```


### PR DESCRIPTION
fixed the backticks in the cloud-hosted guide instructions